### PR TITLE
Add written book to default blacklist [fixes dupe+ah crash]

### DIFF
--- a/src/main/resources/config1.13-Up.yml
+++ b/src/main/resources/config1.13-Up.yml
@@ -301,3 +301,4 @@ Settings:
   BlackList:
     - 'BEDROCK'
     - 'END_PORTAL_FRAME'
+    - 'WRITTEN_BOOK'


### PR DESCRIPTION
Even with illegalstack installed players are able to use mods to list an invalid book on the AH to crash it. Ie the ah will no longer open for others until written books are added to the blacklist

edit:
According to players on my server it can be used for a dupe however I'm not sure how as I disabled the written books as soon as somebody broke the ah with it.